### PR TITLE
wrapped getTypeName() in a try/catch block as its using might result in TypeErrors

### DIFF
--- a/lib/frame.js
+++ b/lib/frame.js
@@ -18,11 +18,22 @@ var util = require('util')
 
 exports.make = make_easy
 
+var safelyGetTypeName = function (frame) {
+  // We need to wrap this within an try/catch block, as we sometimes get
+  // [TypeError: Cannot read property 'constructor' of undefined]
+  // when using 'use strict';
+  try {
+    return frame.getTypeName();
+  } catch (e) {
+    return null;
+  }
+};
+
 function make_easy(call_site) {
   var frame = Object.create(call_site)
 
   frame.this      = frame.getThis()
-  frame.type      = frame.getTypeName()
+  frame.type      = safelyGetTypeName(frame)
   frame.is_top    = frame.isToplevel()
   frame.is_eval   = frame.isEval()
   frame.origin    = frame.getEvalOrigin()

--- a/package.json
+++ b/package.json
@@ -1,18 +1,34 @@
-{ "name": "traceback"
-, "version": "0.3.1"
-, "author": { "name": "Jason Smith" , "email": "jhs@iriscouch.com" }
-, "description": "Easy access to the call stack, written in pure JavaScript"
-, "keywords"   : ["call", "stack", "trace", "stacktrace", "traceback", "debug", "line"]
-, "homepage": "http://github.com/iriscouch/traceback"
-, "repository": { "type": "git"
-                , "url": "git://github.com/iriscouch/traceback" }
-, "engines": [ "node" ]
-
-, "dependencies"   : {
-                     }
-
-, "devDependencies": { "tap": "0.1.3"
-                     }
-
-, "main": "./api"
+{
+  "name": "traceback-safe",
+  "version": "0.3.1-1",
+  "author": {
+    "name": "Jason Smith",
+    "email": "jhs@iriscouch.com"
+  },
+  "contributors": [{
+    "name": "Julian Wagner",
+    "email": "me@waaagner.de"
+  }],
+  "description": "Easy access to the call stack, written in pure JavaScript",
+  "keywords": [
+    "call",
+    "stack",
+    "trace",
+    "stacktrace",
+    "traceback",
+    "debug",
+    "line"
+  ],
+  "homepage": "https://github.com/JulianHH/traceback",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/JulianHH/traceback"
+  },
+  "engines": ["node"],
+  "dependencies": {
+  },
+  "devDependencies": {
+    "tap": "0.1.3"
+  },
+  "main": "./api"
 }


### PR DESCRIPTION
We noticed some strange TypeErrors ([TypeError: Cannot read property 'constructor' of undefined]) as we started using traceback. We figured that it's 'use strict'; whats causing these errors.

So wrapping the call in a try/catch block solves these errors.
